### PR TITLE
Quick fix for issue 6

### DIFF
--- a/src/utils/parseData.js
+++ b/src/utils/parseData.js
@@ -33,11 +33,11 @@ export default function parseData(data, t, encoding) {
       break;
 
     case 'float32':
-      result = data.getFloat32(0);
+      result = data.getFloat32(0, true); // 'littleEndian' works too
       break;
 
     case 'float64':
-      result = data.getFloat64(0);
+      result = data.getFloat64(0, true); // 'littleEndian' works too
       break;
 
     case 'string':


### PR DESCRIPTION
As discussed the proper fix will be pushed later. This fix fixes a more common use case where data is little endian. This would fail if big endian data is passed to p5.ble.js.

@yining1023 I followed the steps mentioned in CONTRIBUTING.md. Everything was a success. Tested the code too using `<script src="http://localhost:8080/p5.ble.js"></script>`. However the modified files in the `dist` folder - which are the actual library that we release - were not committed as they are ignored from the `.gitignore` file. Hence only `parseData.js` has been pushed here.   
Is this correct?
This is my first time developing with javascript so I don't know the exact details. Please let me know if I made a mistake, I will correct it soon.